### PR TITLE
Разметка страницы каталога

### DIFF
--- a/source/catalog.html
+++ b/source/catalog.html
@@ -221,8 +221,8 @@
             <h3>Сахарозаменитель</h3>
           </a>
           <dl class="additional-product__details">
-            <dt class="additional-product___quantity">1 упаковка (100 г)</dt>
-            <dd class="additional-product___price">200 Р.</dd>
+            <dt class="additional-product__quantity">1 упаковка (100 г)</dt>
+            <dd class="additional-product__price">200 Р.</dd>
           </dl>
           <a class="button" href="form.html">Заказать</a>
         </li>
@@ -231,8 +231,8 @@
             <h3>Питьевая вода</h3>
           </a>
           <dl class="additional-product__details">
-            <dt class="additional-product___quantity">5 литров</dt>
-            <dd class="additional-product___price">50 Р.</dd>
+            <dt class="additional-product__quantity">5 литров</dt>
+            <dd class="additional-product__price">50 Р.</dd>
           </dl>
           <a class="button" href="form.html">Заказать</a>
         </li>
@@ -241,8 +241,8 @@
             <h3>Молоко</h3>
           </a>
           <dl class="additional-product__details">
-            <dt class="additional-product___quantity">1 литр</dt>
-            <dd class="additional-product___price">100 Р.</dd>
+            <dt class="additional-product__quantity">1 литр</dt>
+            <dd class="additional-product__price">100 Р.</dd>
           </dl>
           <a class="button" href="form.html">Заказать</a>
         </li>
@@ -251,8 +251,8 @@
             <h3>Витамины</h3>
           </a>
           <dl class="additional-product__details">
-            <dt class="additional-product___quantity">1 упаковка (30 г)</dt>
-            <dd class="additional-product___price">300 Р.</dd>
+            <dt class="additional-product__quantity">1 упаковка (30 г)</dt>
+            <dd class="additional-product__price">300 Р.</dd>
           </dl>
           <a class="button" href="form.html">Заказать</a>
         </li>

--- a/source/catalog.html
+++ b/source/catalog.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html class="page" lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Каталог товаров «Cat Energy»</title>
+</head>
+<body class="page__body">
+  <header class="page-header">
+    <a class="page-header__logo">
+      <img class="page-header__logo-mascot" src="img/header/logo-mascot.svg" width="34" height="38" alt="Логотип">
+      <img class="page-header__logo-text" src="img/header/logo-text.svg" width="101" height="18" alt="Название магазина в виде логотипа — «Cat Energy»">
+    </a>
+    <nav class="main-navigation">
+      <button class="main-navigation__toggle" hidden><span class="visually-hidden">Открыть меню</span></button>
+      <ul class="main-navigation__list">
+        <li class="main-navigation__item">
+          <a href="index.html">Главная</a>
+        </li>
+        <li class="main-navigation__item main-navigation__item--current">
+          <a>Каталог продукции</a>
+        </li>
+        <li class="main-navigation__item">
+          <a href="form.html">Подбор программы</a>
+        </li>
+      </ul>
+    </nav>
+  </header>
+  <main class="page-main">
+    <h1 class="title title--line-height">Каталог продукции</h1>
+    <section class="main-products">
+      <h2 class="visually-hidden">Список товаров</h2>
+      <ul class="products-list">
+        <li class="products-list__item">
+          <article class="product-item">
+            <a class="product-name" href="#">
+              <h3>Cat Energy PRO 500 г</h3>
+            </a>
+            <table class="product-description">
+              <tr>
+                <th class="product-description__title">Масса</th>
+                <td class="product-description__description">500 г</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Вкус</th>
+                <td class="product-description__description">Курица</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Цена</th>
+                <td class="product-description__description">700 Р.</td>
+              </tr>
+            </table>
+            <a class="product-picture" href="#">
+              <img src="https://via.placeholder.com/150x150" width="150" height="150" alt="lorem">
+            </a>
+            <a class="button" href="form.html">Заказать</a>
+          </article>
+        </li>
+        <li class="products-list__item">
+          <article class="product-item">
+            <a class="product-name" href="#">
+              <h3>Cat Energy PRO 1000 г</h3>
+            </a>
+            <table class="product-description">
+              <tr>
+                <th class="product-description__title">Масса</th>
+                <td class="product-description__description">1000 г</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Вкус</th>
+                <td class="product-description__description">Курица</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Цена</th>
+                <td class="product-description__description">1000 Р.</td>
+              </tr>
+            </table>
+            <a class="product-picture" href="#">
+              <img src="https://via.placeholder.com/150x150" width="150" height="150" alt="lorem">
+            </a>
+            <a class="button" href="form.html">Заказать</a>
+          </article>
+        </li>
+        <li class="products-list__item">
+          <article class="product-item">
+            <a class="product-name" href="#">
+              <h3>Cat Energy PRO 500 г</h3>
+            </a>
+            <table class="product-description">
+              <tr>
+                <th class="product-description__title">Масса</th>
+                <td class="product-description__description">500 г</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Вкус</th>
+                <td class="product-description__description">Рыба</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Цена</th>
+                <td class="product-description__description">700 Р.</td>
+              </tr>
+            </table>
+            <a class="product-picture" href="#">
+              <img src="https://via.placeholder.com/150x150" width="150" height="150" alt="lorem">
+            </a>
+            <a class="button" href="form.html">Заказать</a>
+          </article>
+        </li>
+        <li class="products-list__item">
+          <article class="product-item">
+            <a class="product-name" href="#">
+              <h3>Cat Energy PRO 1000 г</h3>
+            </a>
+            <table class="product-description">
+              <tr>
+                <th class="product-description__title">Масса</th>
+                <td class="product-description__description">1000 г</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Вкус</th>
+                <td class="product-description__description">Рыба</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Цена</th>
+                <td class="product-description__description">1000 Р.</td>
+              </tr>
+            </table>
+            <a class="product-picture" href="#">
+              <img src="https://via.placeholder.com/150x150" width="150" height="150" alt="lorem">
+            </a>
+          </article>
+        </li>
+        <li class="products-list__item">
+          <article class="product-item">
+            <a class="product-name" href="#">
+              <h3>Cat Energy slim 500 г</h3>
+            </a>
+            <table class="product-description">
+              <tr>
+                <th class="product-description__title">Масса</th>
+                <td class="product-description__description">500 г</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Вкус</th>
+                <td class="product-description__description">Гречка</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Цена</th>
+                <td class="product-description__description">400 Р.</td>
+              </tr>
+            </table>
+            <a class="product-picture" href="#">
+              <img src="https://via.placeholder.com/150x150" width="150" height="150" alt="lorem">
+            </a>
+            <a class="button" href="form.html">Заказать</a>
+          </article>
+        </li>
+        <li class="products-list__item">
+          <article class="product-item">
+            <a class="product-name" href="#">
+              <h3>Cat Energy slim 1000 г</h3>
+            </a>
+            <table class="product-description">
+              <tr>
+                <th class="product-description__title">Масса</th>
+                <td class="product-description__description">1000 г</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Вкус</th>
+                <td class="product-description__description">Гречка</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Цена</th>
+                <td class="product-description__description">700 Р.</td>
+              </tr>
+            </table>
+            <a class="product-picture" href="#">
+              <img src="https://via.placeholder.com/150x150" width="150" height="150" alt="lorem">
+            </a>
+            <a class="button" href="form.html">Заказать</a>
+          </article>
+        </li>
+        <li class="products-list__item">
+          <article class="product-item">
+            <a class="product-name" href="#">
+              <h3>Cat Energy slim 500 г</h3>
+            </a>
+            <table class="product-description">
+              <tr>
+                <th class="product-description__title">Масса</th>
+                <td class="product-description__description">500 г</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Вкус</th>
+                <td class="product-description__description">Рис</td>
+              </tr>
+              <tr>
+                <th class="product-description__title">Цена</th>
+                <td class="product-description__description">500 Р.</td>
+              </tr>
+            </table>
+            <a class="product-picture" href="#">
+              <img src="https://via.placeholder.com/150x150" width="150" height="150" alt="lorem">
+            </a>
+            <a class="button" href="form.html">Заказать</a>
+          </article>
+        </li>
+        <li class="products-list__item more-items">
+          <h3 class="more-items__title">Показать еще 100500 товаров</h3>
+          <p class="more-items__lead">На самом деле вкусов гораздо больше!</p>
+          <img src="https://via.placeholder.com/60x60" width="60" height="60" alt="lorem"> <!-- Тут будет иконка с плюсом -->
+          <a class="button button--color" href="#">Показать все</a>
+        </li>
+      </ul>
+    </section>
+    <section class="additional-products">
+      <h2>Дополнительные товары</h2>
+      <ul class="additional-products-list">
+        <li class="additional-products-list__item additional-product">
+          <a class="product-name product-name--line-height" href="#">
+            <h3>Сахарозаменитель</h3>
+          </a>
+          <dl class="additional-product__details">
+            <dt class="additional-product___quantity">1 упаковка (100 г)</dt>
+            <dd class="additional-product___price">200 Р.</dd>
+          </dl>
+          <a class="button" href="form.html">Заказать</a>
+        </li>
+        <li class="additional-products-list__item additional-product">
+          <a class="product-name product-name--line-height" href="#">
+            <h3>Питьевая вода</h3>
+          </a>
+          <dl class="additional-product__details">
+            <dt class="additional-product___quantity">5 литров</dt>
+            <dd class="additional-product___price">50 Р.</dd>
+          </dl>
+          <a class="button" href="form.html">Заказать</a>
+        </li>
+        <li class="additional-products-list__item additional-product">
+          <a class="product-name product-name--line-height" href="#">
+            <h3>Молоко</h3>
+          </a>
+          <dl class="additional-product__details">
+            <dt class="additional-product___quantity">1 литр</dt>
+            <dd class="additional-product___price">100 Р.</dd>
+          </dl>
+          <a class="button" href="form.html">Заказать</a>
+        </li>
+        <li class="additional-products-list__item additional-product">
+          <a class="product-name product-name--line-height" href="#">
+            <h3>Витамины</h3>
+          </a>
+          <dl class="additional-product__details">
+            <dt class="additional-product___quantity">1 упаковка (30 г)</dt>
+            <dd class="additional-product___price">300 Р.</dd>
+          </dl>
+          <a class="button" href="form.html">Заказать</a>
+        </li>
+      </ul>
+      <section class="gift-promo">
+        <h3 class="visually-hidden">Как получить подарок</h3>
+        <p class="gift-promo__text">Закажите все и получите чехол для кота в подарок!</p>
+      </section>
+    </section>
+  </main>
+  <footer class="page-footer">
+    <section class="address">
+      <h2 class="visually-hidden">Как нас найти</h2>
+      <div class="address__top-wrapper address__top-wrapper--background">
+        <p class="address__slogan">приглашаем к сотрудничеству дилеров!</p>
+        <p class="address__place">ул. Большая Конюшенная, д. 19/8 Санкт-Петербург</p>
+      </div>
+      <div class="address__bottom-wrapper">
+        <iframe class="map" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3997.118506746264!2d30.3232198!3d59.9394554!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x4696310fca145cc1%3A0x42b32648d8238007!2sBolshaya%20Konyushennaya%20St%2C%2019%2F8%2C%20Sankt-Peterburg%2C%20Rusia%2C%20191186!5e0!3m2!1sro!2sro!4v1616842319284!5m2!1sro!2sro" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+      </div>
+    </section>
+    <div class="page-footer__bottom">
+      <img class="page-footer__logo" src="img/footer/footer-logo.svg" width="128" height="24" alt="Название магазина в виде логотипа — «Cat Energy»">
+      <ul class="social-list">
+        <li class="social-list__item">
+          <a class="social-list__link social-list__link--vkontakte" href="#">
+            <span class="visually-hidden">Перейти на нашу страницу в Вконтакте</span>
+          </a>
+        </li>
+        <li class="social-list__item">
+          <a class="social-list__link social-list__link--instagram" href="#">
+            <span class="visually-hidden">Перейти на нашу страницу в Инстаграме</span>
+          </a>
+        </li>
+        <li class="social-list__item">
+          <a class="social-list__link social-list__link--facebook" href="#">
+            <span class="visually-hidden">Перейти на нашу страницу в Фейсбуке</span>
+          </a>
+        </li>
+      </ul>
+      <a class="page-footer__copy" href="https://htmlacademy.ru/intensive/adaptive">HTML Academy</a>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Словосочетание 'Каталог продукции' было выбрано заголовком первого
уровня.

Страница была разбит на 2 секции - основные товары и дополнительные
товары.

Секции с основными товарами дал заголовок и доступно его скрыл, а в
секции доп. товаров оставил заголовок как в макете.

В секуции с доп. товарами добавил под-секцию с промо-блоком.

Список товаров разметил неупорядочным списком. Основные товары обернул в
тег article, чтобы карточку можно было отделить от страницы и
вставить в другую.

Характеристики основных товаров разметил с помощью таблицы, а
дополнительных с помощью dl.

---
:mortar_board: [Разметка страницы каталога](https://up.htmlacademy.ru/adaptive/22/user/1672121/tasks/4)

:boom: https://htmlacademy-adaptive.github.io/1672121-cat-energy-22/4/