### PR TITLE
Стилизация страницы формы

### DIFF
--- a/source/catalog.html
+++ b/source/catalog.html
@@ -272,7 +272,7 @@
         <p class="address__place">ул. Большая Конюшенная, д. 19/8 Санкт-Петербург</p>
       </div>
       <div class="address__bottom-wrapper">
-        <iframe class="map" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3997.118506746264!2d30.3232198!3d59.9394554!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x4696310fca145cc1%3A0x42b32648d8238007!2sBolshaya%20Konyushennaya%20St%2C%2019%2F8%2C%20Sankt-Peterburg%2C%20Rusia%2C%20191186!5e0!3m2!1sro!2sro!4v1616842319284!5m2!1sro!2sro" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+        <iframe class="map" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3997.118506746264!2d30.3232198!3d59.9394554!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x4696310fca145cc1%3A0x42b32648d8238007!2sBolshaya%20Konyushennaya%20St%2C%2019%2F8%2C%20Sankt-Peterburg%2C%20Rusia%2C%20191186!5e0!3m2!1sro!2sro!4v1616842319284!5m2!1sro!2sro" width="600" height="450" style="border: 0;" allowfullscreen="" loading="lazy"></iframe>
       </div>
     </section>
     <div class="page-footer__bottom">

--- a/source/form.html
+++ b/source/form.html
@@ -6,8 +6,8 @@
   <title>Страница подбора программы питания для вашего кота</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body class="page__body">
-  <header class="page-header">
+<body class="page__body form-body">
+  <header class="form-body__page-header page-header">
     <a class="page-header__logo">
       <img class="page-header__logo-mascot" src="img/header/logo-mascot.svg" width="34" height="38" alt="Логотип">
       <img class="page-header__logo-text" src="img/header/logo-text.svg" width="101" height="18"
@@ -28,10 +28,10 @@
       </ul>
     </nav>
   </header>
-  <main class="page-main">
-    <h1 class="title title--line-height">Подбор программы</h1>
-    <p class="lead">Заполните анкету, и мы подберем программу питания для вашего кота</p>
-    <form class="program-form" action="https://echo.htmlacademy.ru" method="POST">
+  <main class="page-main page-form">
+    <h1 class="page-main__title title">Подбор программы</h1>
+    <p class="page-main__lead">Заполните анкету, и мы подберем программу питания для вашего кота</p>
+    <form class="page-form__program-form program-form" action="https://echo.htmlacademy.ru" method="POST">
       <fieldset class="program-form__fieldset">
         <legend class="visually-hidden">Данные кота</legend>
         <label class="program-form__label" for="cat-name">Имя:*</label>
@@ -43,7 +43,7 @@
       </fieldset>
       <fieldset class="program-form__fieldset">
         <legend class="visually-hidden">Цель подбора питания</legend>
-        <ul class="radio-options-list">
+        <ul class="program-form__radio-options-list radio-options-list">
           <li class="radio-options-list__item">
             <input class="visually-hidden radio-options-list__radio-button" type="radio" id="lose-weight" name="program-goal" value="lose-weight" checked>
             <label class="program-form__label program-form__label--color_a" for="lose-weight">Похудение</label>
@@ -59,20 +59,20 @@
         </ul>
       </fieldset>
       <fieldset class="program-form__fieldset">
-        <legend class="program-form__legend">Контактные данные (владельца кота)</legend>
+        <legend class="program-form__title">Контактные данные (владельца кота)</legend>
         <label class="program-form__label" for="email">E-mail:*</label>
         <input class="program-form__field" type="email" id="email" name="email" placeholder="kuklachev@gmail.com">
         <label class="program-form__label" for="phone-number">Телефон:*</label>
         <input class="program-form__field" type="tel" id="phone-number" name="phone-number" placeholder="8 (960) 900-60-90">
       </fieldset>
       <fieldset class="program-form__fieldset">
-        <legend class="program-form__legend">Комментарий</legend>
+        <legend class="program-form__title">Комментарий</legend>
         <label class="visually-hidden" for="comment-field">Написать комментарий</label>
         <textarea class="comment program-form__field" name="comment-field" id="comment-field" placeholder="Расскажите обо всех повадках кота"></textarea>
       </fieldset>
       <fieldset class="program-form__fieldset">
-        <legend class="program-form__legend">Дополнительно</legend>
-        <ul class="checkbox-options-list">
+        <legend class="program-form__title">Дополнительно</legend>
+        <ul class="program-form__checkbox-options-list checkbox-options-list">
           <li class="checkbox-options-list__item">
             <input class="visually-hidden checkbox-options-list__checkbox" type="checkbox" id="sweetener" name="optional-add" value="sweetener" checked>
             <label class="program-form__label program-form__label--color_b" for="sweetener">Cахарозаменитель</label>
@@ -91,7 +91,7 @@
           </li>
         </ul>
       </fieldset>
-      <button class="button" type="submit">Отправить заявку</button>
+      <button class="submit-button" type="submit">Отправить заявку</button>
       <small class="program-form__legend">* &mdash; Обязательные поля</small>
     </form>
   </main>
@@ -103,7 +103,7 @@
         <p class="address__place">ул. Большая Конюшенная, д. 19/8 Санкт-Петербург</p>
       </div>
       <div class="address__bottom-wrapper">
-        <iframe class="map" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3997.118506746264!2d30.3232198!3d59.9394554!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x4696310fca145cc1%3A0x42b32648d8238007!2sBolshaya%20Konyushennaya%20St%2C%2019%2F8%2C%20Sankt-Peterburg%2C%20Rusia%2C%20191186!5e0!3m2!1sro!2sro!4v1616842319284!5m2!1sro!2sro" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+        <iframe class="map" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3997.118506746264!2d30.3232198!3d59.9394554!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x4696310fca145cc1%3A0x42b32648d8238007!2sBolshaya%20Konyushennaya%20St%2C%2019%2F8%2C%20Sankt-Peterburg%2C%20Rusia%2C%20191186!5e0!3m2!1sro!2sro!4v1616842319284!5m2!1sro!2sro" width="600" height="450" style="border: 0;" allowfullscreen="" loading="lazy"></iframe>
       </div>
     </section>
     <div class="page-footer__bottom">

--- a/source/index.html
+++ b/source/index.html
@@ -118,7 +118,7 @@
           <p class="address__place">ул. Большая Конюшенная, д. 19/8 Санкт-Петербург</p>
         </div>
         <div class="address__bottom-wrapper">
-          <iframe class="map" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3997.118506746264!2d30.3232198!3d59.9394554!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x4696310fca145cc1%3A0x42b32648d8238007!2sBolshaya%20Konyushennaya%20St%2C%2019%2F8%2C%20Sankt-Peterburg%2C%20Rusia%2C%20191186!5e0!3m2!1sro!2sro!4v1616842319284!5m2!1sro!2sro" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+          <iframe class="map" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3997.118506746264!2d30.3232198!3d59.9394554!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x4696310fca145cc1%3A0x42b32648d8238007!2sBolshaya%20Konyushennaya%20St%2C%2019%2F8%2C%20Sankt-Peterburg%2C%20Rusia%2C%20191186!5e0!3m2!1sro!2sro!4v1616842319284!5m2!1sro!2sro" width="600" height="450" style="border: 0;" allowfullscreen="" loading="lazy"></iframe>
         </div>
       </section>
       <div class="page-footer__bottom">

--- a/source/sass/blocks/address.scss
+++ b/source/sass/blocks/address.scss
@@ -23,4 +23,8 @@
 .address__top-wrapper {
   padding-top: 28px;
   padding-bottom: 28px;
+
+  &--background {
+    background-color: var(--basic-grey, #f2f2f2);
+  }
 }

--- a/source/sass/blocks/checkbox-options-list.scss
+++ b/source/sass/blocks/checkbox-options-list.scss
@@ -1,0 +1,3 @@
+.checkbox-options-list {
+  list-style: none;
+}

--- a/source/sass/blocks/form-body.scss
+++ b/source/sass/blocks/form-body.scss
@@ -1,0 +1,3 @@
+.form-body__page-header {
+  margin-bottom: 27px;
+}

--- a/source/sass/blocks/page-form.scss
+++ b/source/sass/blocks/page-form.scss
@@ -1,0 +1,3 @@
+.page-form__program-form {
+  padding-bottom: 32px;
+}

--- a/source/sass/blocks/page-main.scss
+++ b/source/sass/blocks/page-main.scss
@@ -1,0 +1,19 @@
+.page-main {
+  --block-font-special: var(--oswald, "Tahoma", sans-serif);
+}
+
+.page-main__title {
+  margin: 0;
+  margin-bottom: 37px;
+}
+
+.page-main__lead {
+  font-family: var(--block-font-special);
+  font-size: 14px;
+  line-height: 18px;
+  font-weight: 400;
+  text-transform: uppercase;
+  color: var(--basic-black, #000000);
+  margin: 0;
+  margin-bottom: 39px;
+}

--- a/source/sass/blocks/program-form.scss
+++ b/source/sass/blocks/program-form.scss
@@ -39,13 +39,15 @@
 }
 
 .program-form__field {
+  font-family: var(--block-font-special);
+  font-size: 16px;
+  line-height: 18px;
+  font-weight: 400;
+  text-transform: uppercase;
+  color: var(--special-dark-grey, #444444);
+
   &::placeholder {
-    font-family: var(--block-font-special);
-    font-size: 16px;
-    line-height: 18px;
-    font-weight: 400;
-    text-transform: uppercase;
-    color: var(--special-dark-grey, #444444);
+    color: inherit;
   }
 }
 

--- a/source/sass/blocks/program-form.scss
+++ b/source/sass/blocks/program-form.scss
@@ -1,0 +1,68 @@
+.program-form {
+  --block-font-special: var(--oswald, "Tahoma", sans-serif);
+  --block-font-basic: var(--arial, sans-serif);
+}
+
+.program-form__fieldset {
+  border: none;
+  padding: 0;
+
+  &:nth-child(2) {
+    border-top: 1px solid var(--special-white, #d9d9d9);
+    border-bottom: 1px solid var(--special-white, #d9d9d9);
+  }
+}
+
+.program-form__title {
+  font-family: var(--block-font-special);
+  font-size: 24px;
+  line-height: 26px;
+  font-weight: 400;
+  color: var(--basic-black, #000000);
+}
+
+.program-form__label {
+  font-family: var(--block-font-special);
+  font-size: 16px;
+  line-height: 18px;
+  font-weight: 400;
+  text-transform: uppercase;
+  color: var(--special-dark-grey, #444444);
+
+  &--color_a {
+    color: var(--special-dark-grey2, #222222);
+  }
+
+  &--color_b {
+    color: var(--basic-black, #000000);
+  }
+}
+
+.program-form__field {
+  &::placeholder {
+    font-family: var(--block-font-special);
+    font-size: 16px;
+    line-height: 18px;
+    font-weight: 400;
+    text-transform: uppercase;
+    color: var(--special-dark-grey, #444444);
+  }
+}
+
+.program-form__radio-options-list {
+  padding: 0;
+  margin: 0;
+}
+
+.program-form__checkbox-options-list {
+  padding: 0;
+  margin: 0;
+}
+
+.program-form__legend {
+  font-family: var(--block-font-basic);
+  font-size: 14px;
+  line-height: 16px;
+  font-weight: 400;
+  color: var(--basic-black, #000000);
+}

--- a/source/sass/blocks/program-form.scss
+++ b/source/sass/blocks/program-form.scss
@@ -47,7 +47,9 @@
   color: var(--special-dark-grey, #444444);
 
   &::placeholder {
+    font: inherit;
     color: inherit;
+    opacity: 1;
   }
 }
 

--- a/source/sass/blocks/radio-options-list.scss
+++ b/source/sass/blocks/radio-options-list.scss
@@ -1,0 +1,3 @@
+.radio-options-list {
+  list-style: none;
+}

--- a/source/sass/blocks/submit-button.scss
+++ b/source/sass/blocks/submit-button.scss
@@ -1,0 +1,13 @@
+.submit-button {
+  --block-font-special: var(--oswald, "Tahoma", sans-serif);
+  font-family: var(--block-font-special);
+  font-size: 14px;
+  line-height: 18px;
+  font-weight: 400;
+  text-transform: uppercase;
+  color: var(--basic-white, #ffffff);
+  text-decoration: none;
+  background-color: var(--basic-green, #68b738);
+  cursor: pointer;
+  border: none;
+}

--- a/source/sass/global/root.scss
+++ b/source/sass/global/root.scss
@@ -6,6 +6,8 @@
   --basic-grey: #f2f2f2;
   // SPECIAL COLORS
   --special-dark-grey: #444444;
+  --special-dark-grey2: #222222;
+  --special-white: #d9d9d9;
   // BACKGROUND COLORS
   --rgb-basic-green: 104, 183, 56;
   --special-grey-bg: #eaeaea;

--- a/source/sass/style.scss
+++ b/source/sass/style.scss
@@ -8,6 +8,7 @@
 // === BLOCKS ===
 @import "./blocks/visually-hidden.scss";
 @import "./blocks/page.scss";
+@import "./blocks/page-main.scss";
 @import "./blocks/button.scss";
 @import "./blocks/title.scss";
 @import "./blocks/text.scss";
@@ -20,6 +21,12 @@
 @import "./blocks/slider.scss";
 @import "./blocks/page-footer.scss";
 @import "./blocks/address.scss";
+@import "./blocks/form-body.scss";
+@import "./blocks/page-form.scss";
+@import "./blocks/program-form.scss";
+@import "./blocks/radio-options-list.scss";
+@import "./blocks/checkbox-options-list.scss";
+@import "./blocks/submit-button.scss";
 
 // === END BLOCKS ===
 


### PR DESCRIPTION
Были добавлены следующие стили:
- Добавлены параметры шрифтов;
- Добавлены отступы между большими сеточными блоками;
        - тегу body был добавлен блок-класс form-body чтобы добавить
          оступ от шапки сайта, тем самым сохранив независимость блока;
        - тегу main был добавлен блок-класс page-form, чтобы добавить
          внешний отступ для блока формы, и также для шлавного заголовка
          и лида;
- Были обнулены дефолтные отступы (через элемент-сущность),
чтобы подготовить поле для дальнейшейстилизации;
- Тегам legend исправил элемент-классы (у тега small был такой же класс);
- Были обнулены оступы у списков чекбоксов и радио-кнопок.

---
:mortar_board: [Стилизация страницы формы](https://up.htmlacademy.ru/adaptive/22/user/1672121/tasks/8)

:boom: https://htmlacademy-adaptive.github.io/1672121-cat-energy-22/6/